### PR TITLE
leaf-column-cell pass _class param to div

### DIFF
--- a/sites/official/src/lib/datagrid-enhanced/structure/leaf-column-cell.svelte
+++ b/sites/official/src/lib/datagrid-enhanced/structure/leaf-column-cell.svelte
@@ -19,7 +19,8 @@
 	class={cn(
 		datagrid.customization.styling.getHeadRowLeafColumnCellClasses(),
 		column._meta.grow === true && 'grow ',
-		'shrink-0'
+		'shrink-0',
+		_class
 	)}
 	data-pinned={column.state.pinning.position !== 'none' ? column.state.pinning.position : null}
 	style:--pin-left-offset={column.state.pinning.offset + 'px'}


### PR DESCRIPTION
_class param was not passed to the `cn` call, so custom classes were not applied.