### PR TITLE
Fix `particullar` -> `particular` typo in sorting docs

### DIFF
--- a/sites/beta/src/examples/sorting/documentation.md
+++ b/sites/beta/src/examples/sorting/documentation.md
@@ -23,7 +23,7 @@ options: {
 }
 ```
 
-and sorting for particullar column can be overwritten with setting in column definition
+and sorting for particular column can be overwritten with setting in column definition
 
 ```ts
 {


### PR DESCRIPTION
Line 26 of `sites/beta/src/examples/sorting/documentation.md` has `particullar` (extra l) in the sentence about overriding sorting per column.