### PR TITLE
Fix manual sorting condition

### DIFF
--- a/packages/cli/datagrid/core/processors/apply-sorting-fast-sort.ts
+++ b/packages/cli/datagrid/core/processors/apply-sorting-fast-sort.ts
@@ -26,7 +26,7 @@ import { findColumnById, flattenColumnStructureAndClearGroups } from "../utils.s
 export function applySorting<TOriginalRow>(datagrid: DatagridCore<TOriginalRow>, data: TOriginalRow[]): TOriginalRow[] {
     data = datagrid.lifecycleHooks.executePreSort(data);
 
-    const isManualSortingEnabled = datagrid.features.globalSearch.isManual;
+    const isManualSortingEnabled = datagrid.features.sorting.isManual;
     const noSorting = datagrid.features.sorting.sortConfigs.length === 0;
     if (isManualSortingEnabled || noSorting) return data;
 

--- a/packages/cli/datagrid/core/processors/apply-sorting.ts
+++ b/packages/cli/datagrid/core/processors/apply-sorting.ts
@@ -24,7 +24,7 @@ import { findColumnById, flattenColumnStructureAndClearGroups } from "../utils.s
 export function applySorting<TOriginalRow>(datagrid: DatagridCore<TOriginalRow>, data: TOriginalRow[]): TOriginalRow[] {
     data = datagrid.lifecycleHooks.executePreSort(data);
 
-    const isManualSortingEnabled = datagrid.features.globalSearch.isManual || datagrid.features.sorting.isManual;
+    const isManualSortingEnabled = datagrid.features.sorting.isManual;
     const noSorting = datagrid.features.sorting.sortConfigs.length === 0;
     if (isManualSortingEnabled || noSorting) return data;
 

--- a/packages/cli/tests/apply-sorting.test.ts
+++ b/packages/cli/tests/apply-sorting.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { applySorting } from "../datagrid/core/processors/apply-sorting";
+import type { DatagridCore } from "../datagrid/core/index.svelte";
+
+type Row = {
+  value: number;
+};
+
+function createDatagrid({
+  globalSearchIsManual = false,
+  sortingIsManual = false,
+}: {
+  globalSearchIsManual?: boolean;
+  sortingIsManual?: boolean;
+} = {}): DatagridCore<Row> {
+  const column = {
+    type: "accessor",
+    columnId: "value",
+    isSortable: () => true,
+    getValueFn: (row: Row) => row.value,
+  };
+
+  return {
+    _columns: [column],
+    features: {
+      globalSearch: { isManual: globalSearchIsManual },
+      sorting: {
+        isManual: sortingIsManual,
+        sortConfigs: [{ columnId: "value", direction: "ascending" }],
+      },
+    },
+    lifecycleHooks: {
+      executePreSort: (rows: Row[]) => rows,
+      executePostSort: (rows: Row[]) => rows,
+    },
+    processors: {
+      data: {
+        metrics: {
+          measure: (_name: string, callback: () => void) => callback(),
+        },
+      },
+    },
+  } as unknown as DatagridCore<Row>;
+}
+
+describe("applySorting", () => {
+  it("sorts locally when only global search is manual", () => {
+    const rows = [{ value: 2 }, { value: 1 }];
+
+    expect(
+      applySorting(createDatagrid({ globalSearchIsManual: true }), rows),
+    ).toEqual([{ value: 1 }, { value: 2 }]);
+  });
+
+  it("leaves rows unchanged when sorting itself is manual", () => {
+    const rows = [{ value: 2 }, { value: 1 }];
+
+    expect(
+      applySorting(createDatagrid({ sortingIsManual: true }), rows),
+    ).toEqual(rows);
+  });
+});

--- a/sites/beta/vite.config.ts
+++ b/sites/beta/vite.config.ts
@@ -11,6 +11,6 @@ export default defineConfig({
 		})
 	],
 	test: {
-		include: ['src/**/*.{test,spec}.{js,ts}']
+		include: ['src/**/*.{test,spec}.{js,ts}', '../../packages/cli/tests/**/*.{test,spec}.{js,ts}']
 	}
 });

--- a/sites/official/src/lib/datagrid/core/processors/apply-sorting-fast-sort.ts
+++ b/sites/official/src/lib/datagrid/core/processors/apply-sorting-fast-sort.ts
@@ -26,7 +26,7 @@ import { findColumnById, flattenColumnStructureAndClearGroups } from "../utils.s
 export function applySorting<TOriginalRow>(datagrid: DatagridCore<TOriginalRow>, data: TOriginalRow[]): TOriginalRow[] {
     data = datagrid.lifecycleHooks.executePreSort(data);
 
-    const isManualSortingEnabled = datagrid.features.globalSearch.isManual;
+    const isManualSortingEnabled = datagrid.features.sorting.isManual;
     const noSorting = datagrid.features.sorting.sortConfigs.length === 0;
     if (isManualSortingEnabled || noSorting) return data;
 

--- a/sites/official/src/lib/datagrid/core/processors/apply-sorting.ts
+++ b/sites/official/src/lib/datagrid/core/processors/apply-sorting.ts
@@ -24,7 +24,7 @@ import { findColumnById, flattenColumnStructureAndClearGroups } from "../utils.s
 export function applySorting<TOriginalRow>(datagrid: DatagridCore<TOriginalRow>, data: TOriginalRow[]): TOriginalRow[] {
     data = datagrid.lifecycleHooks.executePreSort(data);
 
-    const isManualSortingEnabled = datagrid.features.globalSearch.isManual || datagrid.features.sorting.isManual;
+    const isManualSortingEnabled = datagrid.features.sorting.isManual;
     const noSorting = datagrid.features.sorting.sortConfigs.length === 0;
     if (isManualSortingEnabled || noSorting) return data;
 


### PR DESCRIPTION
Fixes #62.

applySorting currently treats manual global search as manual sorting. That
means local sorting is skipped when globalSearch.isManual is enabled, even if
sorting.isManual is false.

This checks only the sorting feature's own manual flag in both sorting
implementations and keeps the CLI and official-site copies in sync. I also
added a regression test for the mixed manual-search/local-sorting case.

Verification:

- npm run test:unit -- --run - 3 passed
- npm run build - passed
- svelte-check - existing baseline is 161 errors / 5 warnings; this patch has
  the same result and adds no diagnostics
