### PR TITLE
feat: add header column resize handles

### DIFF
--- a/packages/cli/datagrid-enhanced/core/features/column-resizing.svelte.ts
+++ b/packages/cli/datagrid-enhanced/core/features/column-resizing.svelte.ts
@@ -3,6 +3,36 @@ export type ColumnSizingEnhancedPluginConfig = {
     columnResizeMode?: 'standard' | 'fluid';
 }
 
+type ColumnWidthConstraints = {
+    minWidth: number;
+    maxWidth: number;
+}
+
+export function clampColumnWidth(width: number, constraints: ColumnWidthConstraints): number {
+    return Math.max(constraints.minWidth, Math.min(width, constraints.maxWidth));
+}
+
+export function getDraggedColumnWidth(
+    startWidth: number,
+    startClientX: number,
+    currentClientX: number,
+    constraints: ColumnWidthConstraints,
+): number {
+    return clampColumnWidth(startWidth + currentClientX - startClientX, constraints);
+}
+
+export function getKeyboardColumnWidth(
+    currentWidth: number,
+    key: string,
+    constraints: ColumnWidthConstraints,
+    step = 10,
+): number {
+    if (key !== 'ArrowLeft' && key !== 'ArrowRight') return currentWidth;
+
+    const direction = key === 'ArrowLeft' ? -1 : 1;
+    return clampColumnWidth(currentWidth + direction * step, constraints);
+}
+
 export class ColumnSizingEnhancedFeature {
 
     columnResizeMode: 'standard' | 'fluid' = $state('standard') // fluid changes width on mouse move

--- a/packages/cli/datagrid-enhanced/structure/column-resize-handle.svelte
+++ b/packages/cli/datagrid-enhanced/structure/column-resize-handle.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+	import type { LeafColumn } from '$lib/datagrid/core/types';
+	import type { EnhancedDatagrid } from '../core/index.svelte';
+	import {
+		getDraggedColumnWidth,
+		getKeyboardColumnWidth
+	} from '../core/features/column-resizing.svelte';
+
+	type Props = {
+		datagrid: EnhancedDatagrid;
+		column: LeafColumn<any>;
+	};
+
+	let { datagrid, column }: Props = $props();
+	let startClientX = 0;
+	let startWidth = 0;
+	let resizing = false;
+
+	const constraints = () => ({
+		minWidth: column.state.size.minWidth || 0,
+		maxWidth: column.state.size.maxWidth || Number.MAX_SAFE_INTEGER
+	});
+
+	function updateWidth(width: number) {
+		datagrid.handlers.column.updateColumnSize(column.columnId, width);
+	}
+
+	function handlePointerDown(event: PointerEvent) {
+		if (event.button !== 0) return;
+
+		event.preventDefault();
+		event.stopPropagation();
+		startClientX = event.clientX;
+		startWidth = column.state.size.width;
+		resizing = true;
+		const handle = event.currentTarget as HTMLButtonElement;
+		handle.setPointerCapture(event.pointerId);
+	}
+
+	function handlePointerMove(event: PointerEvent) {
+		if (!resizing) return;
+
+		event.preventDefault();
+		event.stopPropagation();
+		if (datagrid.extra.features.columnSizing.columnResizeMode !== 'fluid') return;
+
+		updateWidth(getDraggedColumnWidth(startWidth, startClientX, event.clientX, constraints()));
+	}
+
+	function handlePointerEnd(event: PointerEvent, cancelled = false) {
+		if (!resizing) return;
+
+		event.preventDefault();
+		event.stopPropagation();
+		if (!cancelled && datagrid.extra.features.columnSizing.columnResizeMode === 'standard') {
+			updateWidth(getDraggedColumnWidth(startWidth, startClientX, event.clientX, constraints()));
+		}
+		resizing = false;
+		const handle = event.currentTarget as HTMLButtonElement;
+		if (handle.hasPointerCapture(event.pointerId)) {
+			handle.releasePointerCapture(event.pointerId);
+		}
+	}
+
+	function handleKeyDown(event: KeyboardEvent) {
+		if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
+
+		event.preventDefault();
+		event.stopPropagation();
+		updateWidth(getKeyboardColumnWidth(column.state.size.width, event.key, constraints()));
+	}
+</script>
+
+<button
+	type="button"
+	class="column-resize-handle"
+	aria-label={`Resize ${column.header} column`}
+	title={`Resize ${column.header} column`}
+	onclick={(event) => event.stopPropagation()}
+	onpointerdown={handlePointerDown}
+	onpointermove={handlePointerMove}
+	onpointerup={(event) => handlePointerEnd(event)}
+	onpointercancel={(event) => handlePointerEnd(event, true)}
+	onkeydown={handleKeyDown}
+></button>
+
+<style>
+	.column-resize-handle {
+		position: absolute;
+		top: 0;
+		right: -4px;
+		z-index: 3;
+		height: 100%;
+		width: 8px;
+		cursor: col-resize;
+		touch-action: none;
+		user-select: none;
+		border: 0;
+		padding: 0;
+		background: transparent;
+	}
+
+	.column-resize-handle::after {
+		position: absolute;
+		top: 20%;
+		bottom: 20%;
+		left: 3px;
+		width: 2px;
+		border-radius: 9999px;
+		background: currentColor;
+		content: '';
+		opacity: 0;
+	}
+
+	.column-resize-handle:hover::after,
+	.column-resize-handle:focus-visible::after,
+	.column-resize-handle:active::after {
+		opacity: 0.45;
+	}
+</style>

--- a/packages/cli/datagrid-enhanced/structure/leaf-column-cell.svelte
+++ b/packages/cli/datagrid-enhanced/structure/leaf-column-cell.svelte
@@ -4,6 +4,7 @@
 	import type { Snippet } from 'svelte';
 	import type { EnhancedDatagrid } from '../core/index.svelte';
 	import type { ColumnMetaEnhanced } from '../core/types';
+	import ColumnResizeHandle from './column-resize-handle.svelte';
 
 	type Props = {
 		datagrid: EnhancedDatagrid;
@@ -19,7 +20,7 @@
 	class={cn(
 		datagrid.customization.styling.getHeadRowLeafColumnCellClasses(),
 		column._meta.grow === true && 'grow ',
-		'shrink-0',
+		'relative shrink-0',
 		_class
 	)}
 	data-pinned={column.state.pinning.position !== 'none' ? column.state.pinning.position : null}
@@ -30,4 +31,7 @@
 	style:--max-width={column.state.size.maxWidth + 'px'}
 >
 	{@render children()}
+	{#if column.options.resizable}
+		<ColumnResizeHandle {datagrid} {column} />
+	{/if}
 </div>

--- a/packages/cli/tests/column-resizing.test.ts
+++ b/packages/cli/tests/column-resizing.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  clampColumnWidth,
+  getDraggedColumnWidth,
+  getKeyboardColumnWidth,
+} from '../datagrid-enhanced/core/features/column-resizing.svelte';
+
+const constraints = { minWidth: 80, maxWidth: 240 };
+
+describe('column resizing', () => {
+  it('calculates a dragged width from the initial pointer position', () => {
+    expect(getDraggedColumnWidth(120, 200, 245, constraints)).toBe(165);
+    expect(getDraggedColumnWidth(120, 200, 170, constraints)).toBe(90);
+  });
+
+  it('clamps dragged widths to the configured limits', () => {
+    expect(getDraggedColumnWidth(120, 200, 100, constraints)).toBe(80);
+    expect(getDraggedColumnWidth(120, 200, 400, constraints)).toBe(240);
+    expect(clampColumnWidth(160, constraints)).toBe(160);
+  });
+
+  it('resizes with arrow keys while preserving limits', () => {
+    expect(getKeyboardColumnWidth(120, 'ArrowLeft', constraints)).toBe(110);
+    expect(getKeyboardColumnWidth(120, 'ArrowRight', constraints)).toBe(130);
+    expect(getKeyboardColumnWidth(80, 'ArrowLeft', constraints)).toBe(80);
+    expect(getKeyboardColumnWidth(240, 'ArrowRight', constraints)).toBe(240);
+  });
+
+  it('ignores unrelated keys', () => {
+    expect(getKeyboardColumnWidth(120, 'Enter', constraints)).toBe(120);
+  });
+});

--- a/sites/official/src/lib/datagrid-enhanced/core/features/column-resizing.svelte.ts
+++ b/sites/official/src/lib/datagrid-enhanced/core/features/column-resizing.svelte.ts
@@ -3,6 +3,36 @@ export type ColumnSizingEnhancedPluginConfig = {
     columnResizeMode?: 'standard' | 'fluid';
 }
 
+type ColumnWidthConstraints = {
+    minWidth: number;
+    maxWidth: number;
+}
+
+export function clampColumnWidth(width: number, constraints: ColumnWidthConstraints): number {
+    return Math.max(constraints.minWidth, Math.min(width, constraints.maxWidth));
+}
+
+export function getDraggedColumnWidth(
+    startWidth: number,
+    startClientX: number,
+    currentClientX: number,
+    constraints: ColumnWidthConstraints,
+): number {
+    return clampColumnWidth(startWidth + currentClientX - startClientX, constraints);
+}
+
+export function getKeyboardColumnWidth(
+    currentWidth: number,
+    key: string,
+    constraints: ColumnWidthConstraints,
+    step = 10,
+): number {
+    if (key !== 'ArrowLeft' && key !== 'ArrowRight') return currentWidth;
+
+    const direction = key === 'ArrowLeft' ? -1 : 1;
+    return clampColumnWidth(currentWidth + direction * step, constraints);
+}
+
 export class ColumnSizingEnhancedFeature {
 
     columnResizeMode: 'standard' | 'fluid' = $state('standard') // fluid changes width on mouse move

--- a/sites/official/src/lib/datagrid-enhanced/structure/column-resize-handle.svelte
+++ b/sites/official/src/lib/datagrid-enhanced/structure/column-resize-handle.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+	import type { LeafColumn } from '$lib/datagrid/core/types';
+	import type { EnhancedDatagrid } from '../core/index.svelte';
+	import {
+		getDraggedColumnWidth,
+		getKeyboardColumnWidth
+	} from '../core/features/column-resizing.svelte';
+
+	type Props = {
+		datagrid: EnhancedDatagrid;
+		column: LeafColumn<any>;
+	};
+
+	let { datagrid, column }: Props = $props();
+	let startClientX = 0;
+	let startWidth = 0;
+	let resizing = false;
+
+	const constraints = () => ({
+		minWidth: column.state.size.minWidth || 0,
+		maxWidth: column.state.size.maxWidth || Number.MAX_SAFE_INTEGER
+	});
+
+	function updateWidth(width: number) {
+		datagrid.handlers.column.updateColumnSize(column.columnId, width);
+	}
+
+	function handlePointerDown(event: PointerEvent) {
+		if (event.button !== 0) return;
+
+		event.preventDefault();
+		event.stopPropagation();
+		startClientX = event.clientX;
+		startWidth = column.state.size.width;
+		resizing = true;
+		const handle = event.currentTarget as HTMLButtonElement;
+		handle.setPointerCapture(event.pointerId);
+	}
+
+	function handlePointerMove(event: PointerEvent) {
+		if (!resizing) return;
+
+		event.preventDefault();
+		event.stopPropagation();
+		if (datagrid.extra.features.columnSizing.columnResizeMode !== 'fluid') return;
+
+		updateWidth(getDraggedColumnWidth(startWidth, startClientX, event.clientX, constraints()));
+	}
+
+	function handlePointerEnd(event: PointerEvent, cancelled = false) {
+		if (!resizing) return;
+
+		event.preventDefault();
+		event.stopPropagation();
+		if (!cancelled && datagrid.extra.features.columnSizing.columnResizeMode === 'standard') {
+			updateWidth(getDraggedColumnWidth(startWidth, startClientX, event.clientX, constraints()));
+		}
+		resizing = false;
+		const handle = event.currentTarget as HTMLButtonElement;
+		if (handle.hasPointerCapture(event.pointerId)) {
+			handle.releasePointerCapture(event.pointerId);
+		}
+	}
+
+	function handleKeyDown(event: KeyboardEvent) {
+		if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
+
+		event.preventDefault();
+		event.stopPropagation();
+		updateWidth(getKeyboardColumnWidth(column.state.size.width, event.key, constraints()));
+	}
+</script>
+
+<button
+	type="button"
+	class="column-resize-handle"
+	aria-label={`Resize ${column.header} column`}
+	title={`Resize ${column.header} column`}
+	onclick={(event) => event.stopPropagation()}
+	onpointerdown={handlePointerDown}
+	onpointermove={handlePointerMove}
+	onpointerup={(event) => handlePointerEnd(event)}
+	onpointercancel={(event) => handlePointerEnd(event, true)}
+	onkeydown={handleKeyDown}
+></button>
+
+<style>
+	.column-resize-handle {
+		position: absolute;
+		top: 0;
+		right: -4px;
+		z-index: 3;
+		height: 100%;
+		width: 8px;
+		cursor: col-resize;
+		touch-action: none;
+		user-select: none;
+		border: 0;
+		padding: 0;
+		background: transparent;
+	}
+
+	.column-resize-handle::after {
+		position: absolute;
+		top: 20%;
+		bottom: 20%;
+		left: 3px;
+		width: 2px;
+		border-radius: 9999px;
+		background: currentColor;
+		content: '';
+		opacity: 0;
+	}
+
+	.column-resize-handle:hover::after,
+	.column-resize-handle:focus-visible::after,
+	.column-resize-handle:active::after {
+		opacity: 0.45;
+	}
+</style>

--- a/sites/official/src/lib/datagrid-enhanced/structure/leaf-column-cell.svelte
+++ b/sites/official/src/lib/datagrid-enhanced/structure/leaf-column-cell.svelte
@@ -4,6 +4,7 @@
 	import type { Snippet } from 'svelte';
 	import type { EnhancedDatagrid } from '../core/index.svelte';
 	import type { ColumnMetaEnhanced } from '../core/types';
+	import ColumnResizeHandle from './column-resize-handle.svelte';
 
 	type Props = {
 		datagrid: EnhancedDatagrid;
@@ -19,7 +20,7 @@
 	class={cn(
 		datagrid.customization.styling.getHeadRowLeafColumnCellClasses(),
 		column._meta.grow === true && 'grow ',
-		'shrink-0',
+		'relative shrink-0',
 		_class
 	)}
 	data-pinned={column.state.pinning.position !== 'none' ? column.state.pinning.position : null}
@@ -30,4 +31,7 @@
 	style:--max-width={column.state.size.maxWidth + 'px'}
 >
 	{@render children()}
+	{#if column.options.resizable}
+		<ColumnResizeHandle {datagrid} {column} />
+	{/if}
 </div>


### PR DESCRIPTION
## Summary
- add an Excel-style drag handle to resizable leaf-column headers
- preserve standard and fluid resize modes plus min/max constraints
- support keyboard resizing and keep CLI/official copies in sync
- add regression coverage for width calculation

## Testing
- direct TypeScript assertions for drag, clamping, and keyboard resizing
- `git diff --check`

Full Vitest/Svelte/build validation could not be run locally because package installation repeatedly failed with `ECONNRESET` (and npm reported `Exit handler never called!`).

Addresses #63